### PR TITLE
getStats argument length should be reported as zero

### DIFF
--- a/src/js/firefox/firefox_shim.js
+++ b/src/js/firefox/firefox_shim.js
@@ -72,11 +72,11 @@ export function shimPeerConnection(window) {
   };
 
   const nativeGetStats = window.RTCPeerConnection.prototype.getStats;
-  window.RTCPeerConnection.prototype.getStats = function(
-    selector,
-    onSucc,
-    onErr
-  ) {
+  window.RTCPeerConnection.prototype.getStats = function() {
+    var selector = arguments[0]
+    var onSucc = arguments[1]
+    var onErr = arguments[2]
+
     return nativeGetStats.apply(this, [selector || null])
       .then(stats => {
         if (browserDetails.version < 53 && !onSucc) {


### PR DESCRIPTION
**Description**

```js
window.RTCPeerConnection.prototype.getStats.length === 0
```

**Purpose**

This fixes compatibility with simple-peer. Simple Peer only uses the newer promise-based API if getStats.length === 0.

Resolves this issue: https://github.com/feross/simple-peer/issues/470
